### PR TITLE
Add Proxy support and pre-run IP address checking

### DIFF
--- a/.env.example
+++ b/.env.example
@@ -9,3 +9,14 @@ HANDLE_DRIVER= True or False
 # Full list of services and their URLs available here: https://github.com/caronc/apprise/wiki
 # Set to be alerted when new giveaway tweet is found
 APPRISE_ALERTS=
+
+# Your desired external IPv4 address
+# Optional, if you don't want to check that your external IPv4 is the same as your desired IPv4
+WANTED_IPV4=
+# Your desired external IPv6 address
+# Optional, if you don't want to check that your external IPv6 is the same as your desired IPv6
+WANTED_IPV6=
+
+# Configure a HTTP(S) or SOCKS5 proxy through which all of the bot's traffic will go
+# Should be in a URI format (e.g., https://1.2.3.4:5678)
+PROXY=

--- a/main.py
+++ b/main.py
@@ -46,7 +46,7 @@ if APPRISE_ALERTS:
 
 HANDLE_DRIVER = os.environ.get("HANDLE_DRIVER", "False")
 
-if (HANDLE_DRIVER == "True"):
+if (HANDLE_DRIVER.lower() == "true"):
     HANDLE_DRIVER = True
 else:
     HANDLE_DRIVER = False
@@ -90,7 +90,7 @@ def get_current_ip(type, proxies):
                     title=f"Failed to connect to icanhazip.com over {type}",
                     body=f"Is there a problem with your network?"
                 )
-            # Wait some time (to prevent Docker containers from constantly restarting), but only in Docker mode
+            # Wait some time (to prevent Docker containers from constantly restarting)
             sleep(300)
             raise Exception(
                 f"Failed to connect to icanhazip.com over {type}. Is there a problem with your network?"
@@ -112,7 +112,7 @@ def get_current_ip(type, proxies):
                 title=f"An exception occurred while trying to get your current IP address",
                 body=f"{e}"
             )
-        # Wait some time (to prevent Docker containers from constantly restarting), but only in Docker mode
+        # Wait some time (to prevent Docker containers from constantly restarting)
         sleep(60)
         raise Exception
 
@@ -345,7 +345,7 @@ def getDriver(isMobile = False):
 
     if proxy:
         chrome_options.add_argument(f'--proxy-server={proxy}')
-        print(f"Set Edge proxy to {proxy}")
+        print(f"Set Chrome proxy to {proxy}")
     chrome_options.add_argument('--no-sandbox')
     chrome_options.add_argument('--disable-dev-shm-usage')
     if (isMobile):   
@@ -577,6 +577,7 @@ def main():
     #totalPointsReport = 0
     return
 
+# Main function
 if __name__ == "__main__":
     # Initialize apprise alerts
     if APPRISE_ALERTS:
@@ -589,7 +590,6 @@ if __name__ == "__main__":
     current_ipv6 = get_current_ip("v6", proxies)
     if current_ipv6:
         print(f"Current IPv6 Address: {current_ipv6}")
-
     # If declared in .env, check the IPv4 address
     if wanted_ipv4:
         # Raise exception if they don't match, otherwise print success and continue
@@ -607,23 +607,24 @@ if __name__ == "__main__":
             )
         else:
             print("IPv4 addresses match!")
-        # If declared in .env, check the IPv6 address
-        if wanted_ipv6 and current_ipv6:
-            # Raise exception if they don't match, otherwise print success and continue
-            if wanted_ipv6 != current_ipv6:
-                # Send message to console and apprise if configured
-                print(
-                    f"IPv6 addresses do not match. Wanted {wanted_ipv6} but got {current_ipv6}",
-                    "error",
-                )
-                if APPRISE_ALERTS:
-                    alerts.notify(title=f'IPv6 Address Mismatch', 
-                        body=f'Wanted {wanted_ipv6} but got {current_ipv6}')
-                raise Exception(
-                    f"IPv6 addresses do not match. Wanted {wanted_ipv6} but got {current_ipv6}"
-                )
-            else:
-                print("IPv6 addresses match!")
+    # If declared in .env, check the IPv6 address
+    if wanted_ipv6 and current_ipv6:
+        # Raise exception if they don't match, otherwise print success and continue
+        if wanted_ipv6 != current_ipv6:
+            # Send message to console and apprise if configured
+            print(
+                f"IPv6 addresses do not match. Wanted {wanted_ipv6} but got {current_ipv6}",
+                "error",
+            )
+            if APPRISE_ALERTS:
+                alerts.notify(title=f'IPv6 Address Mismatch', 
+                    body=f'Wanted {wanted_ipv6} but got {current_ipv6}')
+            raise Exception(
+                f"IPv6 addresses do not match. Wanted {wanted_ipv6} but got {current_ipv6}"
+            )
+        else:
+            print("IPv6 addresses match!")
+
     # If IP checks pass, then start main loop
     while True:
         try:

--- a/requirements.txt
+++ b/requirements.txt
@@ -3,3 +3,4 @@ python-dotenv==0.20.0
 RandomWords==0.3.0
 selenium==4.3.0
 webdriver-manager==3.7.0
+requests==2.27.1


### PR DESCRIPTION
Add support for proxies and checking to be sure we have the correct IP address before the bot is ran. This is accomplished by setting the appropriate env variables which enables the flag in chrome launch options. The bot will also optionally check your current IP address against a desired IP address (both v4 and v6) and quit if they don't match. 