### PR TITLE
Fixes on Firefox support

### DIFF
--- a/main.py
+++ b/main.py
@@ -105,7 +105,7 @@ if (HANDLE_DRIVER == "true"):
         from selenium.webdriver.edge.service                          import Service
     elif BROWSER == "firefox":
         from webdriver_manager.firefox                                import GeckoDriverManager
-        from selenium.webdriver.firefox.options                       import Options
+        from selenium.webdriver.firefox.service                       import Service 
 else:
     HANDLE_DRIVER = False
 
@@ -298,10 +298,7 @@ def get_driver(isMobile = False):
         options = webdriver.FirefoxOptions()
 
     if HEADLESS:
-        if BROWSER == "chrome" or BROWSER == "edge":
-            options.add_argument("--headless")
-        elif BROWSER == "firefox":
-            options.headless = True
+        options.add_argument("--headless")
 
     options.add_argument('--no-sandbox')
     options.add_argument('--disable-dev-shm-usage')


### PR DESCRIPTION
There is `import Options` statement [here](https://github.com/Prem-ium/BingRewards/blob/94b4165140602b1af24672a30b4b853fc369a429/main.py#L108), however, the Service() is used [here](https://github.com/Prem-ium/BingRewards/blob/94b4165140602b1af24672a30b4b853fc369a429/main.py#L335). In addition to that, `options.add_argument("-headless")` should also work on Firefox after applying this fix.